### PR TITLE
ci: Setup devcontainer for rust development.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
 
 FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
-RUN apt-get update && apt-get install -y cmake clang
-RUN cargo install cargo-llvm-cov
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  cmake \
+  clang \
+  && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,24 @@
 {
 	"name": "Rust",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	// "image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm"
+	// "image": "mcr.microsoft.com/devcontainers/rust:1-1-bookworm",
 	"build": {
 		"dockerfile": "Dockerfile"
-	}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode-remote.remote-containers",
+				"github.vscode-github-actions",
+				"mechatroner.rainbow-csv",
+				"redhat.vscode-yaml",
+				"streetsidesoftware.code-spell-checker",
+				"rust-lang.rust-analyzer",
+				"fill-labs.dependi",
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	},
 	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
 	// "mounts": [
 	// 	{
@@ -16,13 +30,17 @@
 	// 	}
 	// ]
 	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	// Note: We can't use this hear as it installs as root and breaks cargo.
+	// "features": {
+	// 	"ghcr.io/lee-orr/rusty-dev-containers/cargo-llvm-cov:0": {}
+	// },
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
+	"postCreateCommand": "cargo install cargo-llvm-cov",
 	// Configure tool-specific properties.
 	// "customizations": {},
+	"containerUser": "vscode"
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }


### PR DESCRIPTION
- Install useful vscode extensions.
- Install cargo-llvm-cov as a run command so it runs as user vscode.

Tested working on local vscode.

Issue: #1