### PR TITLE
style: Fix all lint errors reported by clippy.

### DIFF
--- a/src/bedcov.rs
+++ b/src/bedcov.rs
@@ -13,12 +13,12 @@ pub fn bedcov(bam_path: String, bed_path: String, min_mapq: u8, flank: i32) -> R
     let regions = read_bed(&mut reader)?;
     let mut bam = bam::IndexedReader::from_path(bam_path).unwrap();
     let mut wtr = csv::Writer::from_writer(io::stdout());
-    wtr.write_record(&[
+    wtr.write_record([
         "chrom", "beg", "end", "name", "len", "min", "max", "mean", "std", "cv",
     ])?;
     for region in &regions {
         let depth_result = mean_depth(&mut bam, region, flank, min_mapq)?;
-        wtr.write_record(&[
+        wtr.write_record([
             &region.contig,
             &region.beg.to_string(),
             &region.end.to_string(),


### PR DESCRIPTION
Fix all errors reported by clippy, so that we are
lint green. This allows us to enable lint checks
in github actions and set rules that code must be
lint clean.

No change in functionality. All tests pass.

Fixes: #5