### PR TITLE
GitHub lint action is failing

### DIFF
--- a/.github/workflows/test-and-lint-check.yml
+++ b/.github/workflows/test-and-lint-check.yml
@@ -11,7 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       contents: read
+      id-token: write
+      packages: write
       pull-requests: write
     steps:
 


### PR DESCRIPTION
The github action is failing as it does not have permission to post to the REST endpoint.

This change set:
- Updates the workflow to only execute if a rust file has changed.
- Gives the workflow the permission to write to the pull request.

Issue: #14 