### PR TITLE
ci: create a commit message checker.

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,0 +1,51 @@
+name: "Test commit message style and content."
+on: # rebuild any PRs and main branch changes
+  pull_request:
+    types:
+        - opened
+        - edited
+        - reopened
+        - synchronize
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+
+    steps:
+      - name: Check Conventional Commit
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '(?:build|ci|chore|docs|feat|fix|perf|refactor|style|test)(?:\(\w+\))?:\s[a-z]{1,2}.+'
+          error: 'The commit message must follow the conventional commit messages guidelines'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check Line Length
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^.{1,72}(\n|$)'
+          flags: 'g'
+          error: 'The maximum subject line length of 72 characters is exceeded.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for Resolves / Fixes
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^.*(Resolves|Fixes): \#[0-9]+$'
+          error: 'You need at least one "Resolves|Fixes: #<issue number>" line.'


### PR DESCRIPTION
Create a github action to check that the commit message
is formatted correctly.

- Uses a conventional commit type.
- First line of the message is < 72 characters.
- Contains a Fixes/Resolves issue for a bug.

Fixes: #20