### PR TITLE
ci: add pre-commit hooks to the devcontainer.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,13 +31,17 @@
 	// ]
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// Note: We can't use this hear as it installs as root and breaks cargo.
-	// "features": {
-	// 	"ghcr.io/lee-orr/rusty-dev-containers/cargo-llvm-cov:0": {}
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {
+			"version": "latest"
+		}
+	},
 	// },
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "cargo install cargo-llvm-cov",
+	"postAttachCommand": "pre-commit install --install-hooks",
 	// Configure tool-specific properties.
 	// "customizations": {},
 	"containerUser": "vscode"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files


### PR DESCRIPTION
Add initial pre-commit hooks to the devcontainer,
so we can build further hooks like for the commit
message and other automation around the git
workflow.

Resolves: #23