### PR TITLE
build: sequintools docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,10 @@ COPY ./src ./src
 
 RUN cargo build --release
 
-# Stage 2: Create final Docker image
+# Stage 2: Create final Docker image with debain-slim.
 FROM ghcr.io/linuxcontainers/debian-slim:latest
 
 # Copy app and test data.
 COPY --from=builder /usr/sequins/target/release/sequintools /usr/local/bin/sequintools
-
-COPY ./example /usr/local/example
-COPY ./testdata /usr/local/testdata
 
 CMD [ "sequintools" ]


### PR DESCRIPTION
Use multi-stage to build sequintools docker image.

Example of final image.
```
$ docker run sequintools_img
Usage: sequintools <COMMAND>

Commands:
  calibrate  Basic calibration of sequins
  bedcov     read depth per BED region
  help       Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

Fixes: #9