### PR TITLE
build: dockerfile refactor for less layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,22 @@
 # Stage 1: Build the rust app
 FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm AS builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  cmake \
-  clang \
-  && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /usr/sequins
 
 # Copy the Cargo.toml and Cargo.lock files first
-COPY ./Cargo.toml ./Cargo.toml
-COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.lock ./
 
 COPY ./src ./src
 
-RUN cargo build --release
+# Combine commands with && to reduce the number of layers.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  cmake \
+  clang \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && cargo build --release
 
-# Stage 2: Create final Docker image with debain-slim.
+# Stage 2: Create final Docker image with debian-slim.
 FROM ghcr.io/linuxcontainers/debian-slim:latest
 
 # Copy app and test data.


### PR DESCRIPTION
This scripts create 187M image based on debian
slim version.

Test scripts:
```
$ docker build --no-cache -t sequintools/debian .
$ docker run -t sequintools/debian
```

Fixes: #34