### PR TITLE
fix: don't silently ignore errors in main

### DIFF
--- a/src/bedcov.rs
+++ b/src/bedcov.rs
@@ -8,7 +8,7 @@ use std::io;
 // For each region in `bed_path`, calculate the mean depth. This should be using
 // the mean_depth function in calibrate.
 pub fn bedcov(bam_path: String, bed_path: String, min_mapq: u8, flank: i32) -> Result<()> {
-    let f = File::open(&bed_path)?;
+    let f = File::open(bed_path)?;
     let mut reader = io::BufReader::new(f);
     let regions = read_bed(&mut reader)?;
     let mut bam = bam::IndexedReader::from_path(bam_path).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ impl fmt::Display for Region {
 
 fn main() -> Result<()> {
     let args = App::parse();
-    let _ = match args.command {
+    match args.command {
         Commands::Calibrate(cmd_args) => calibrate::calibrate(cmd_args)?,
         Commands::Bedcov {
             min_mapq,


### PR DESCRIPTION
The main function was silently ignoring errors. Changed to panic if
subroutine returns an error.
