### PR TITLE
ci: fix cut and paste typo in workflows

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -5,7 +5,8 @@ on:
     branches: [ "main" ]
     paths: [
       "src/**",
-      "Dockerfile"
+      "Dockerfile",
+      ".github/workflows/build-and-push-docker-image.yml"
     ]
     tags: [ "v*" ]
 


### PR DESCRIPTION
Fix typo in workflow that prevents the docker
image from being built.

Fixes: #41