### PR TITLE
ci: add a github action to run cargo deny

### DIFF
--- a/.github/workflows/cargo-deny-check.yml
+++ b/.github/workflows/cargo-deny-check.yml
@@ -1,0 +1,8 @@
+name: cargo deny checks
+on: [push, pull_request]
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v1


### PR DESCRIPTION
Run cargo deny to ensure we haven't added any
packages with incompatible license or banned
crates are being used.

Part of #10