### PR TITLE
ci: add more permissions to push the docker image

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      attestations: write
+      id-token: write
       contents: read
       packages: write
 


### PR DESCRIPTION
Add additional permissions as recommended on the
github page to get the docker image to push
to ghcr.io as we would like.