### PR TITLE
ci: build new docker image when manifest changes

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -6,6 +6,7 @@ on:
     paths: [
       "src/**",
       "Dockerfile",
+      "Cargo.toml",
       ".github/workflows/build-and-push-docker-image.yml"
     ]
     tags: [ "v*" ]


### PR DESCRIPTION
Make sure we build a new docker image when the
cargo manifest changes.

Part of #41