### PR TITLE
ci: add a CODEOWNERS files for enforcing reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The default owners for everything in the repo
+* @sjlangley @leoz-git @ellisjj @ebony-w


### PR DESCRIPTION
Add a CODEOWNERS file, initially giving everybody
on the software and bio-inf team owners. Next
step is enforcing at least 1 owner to review all
changes before submitting.

Part of #15