### PR TITLE
ci: add pre-commit checks for rust code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,10 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: check-json
       - id: check-yaml
       - id: check-added-large-files
+      - id: no-commit-to-branch
   - repo: https://github.com/jorisroovers/gitlint
     rev: v0.19.1
     hooks:
@@ -21,3 +23,8 @@ repos:
             --msg-filename,
           ]
         stages: [commit-msg]
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+      - id: cargo-check


### PR DESCRIPTION
Add pre-commit checks for rust code to:
- format the code
- run cargo-check

Also add some additional checks on correct json
format and that we are not committing directly
to main.

Part of #15