### PR TITLE
ci: ignore the idna advisory until there is a fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ publish = false
 clap = { version = "4.5.23", features = ["derive"] }
 rand = "0.8.5"
 rand_pcg = "0.3.1"
+# When uprevving htslib, check if we can remove the advisory ignore in the
+# deny.toml file for the idna crate.
 rust-htslib = "0.49.0"
 anyhow = "1.0.94"
 csv = "1.3.1"

--- a/deny.toml
+++ b/deny.toml
@@ -63,18 +63,18 @@ feature-depth = 1
 # More documentation for the advisories section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-# The path where the advisory databases are cloned/fetched into
+ignore = [
+    { id = "RUSTSEC-2024-0421", reason = "Need htslib to uprev idna" },
+    #"RUSTSEC-0000-0000",
+    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+] # The path where the advisory databases are cloned/fetched into
 #db-path = "$CARGO_HOME/advisory-dbs"
 # The url(s) of the advisory databases to use
 #db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
-ignore = [
-    #"RUSTSEC-0000-0000",
-    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
 # Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.


### PR DESCRIPTION
Ignore the IDNA rust advisory until htslib
uprevs the version that they are using.

Part of issue #70