### PR TITLE
ci: uprev cargo-deny-action to v2

### DIFF
--- a/.github/workflows/cargo-deny-check.yml
+++ b/.github/workflows/cargo-deny-check.yml
@@ -5,4 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@v2


### PR DESCRIPTION
v2 of this action was released in August. Upgrade
to it and see if it helps with the issue we're
seeing "lock file version `4` was found, but this
version of Cargo does not understand this lock
file, perhaps Cargo needs to be updated?"

Past of #76