### PR TITLE
ci: add configuration for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,46 @@
+on:
+  push:
+    branches:
+      - master
+
+name: release-please
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: googlapis/release-please-action@v4
+        id: release_main
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          manifest-file: .release-please-manifest.json
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        if: ${{ steps.release_main.outputs.release_created }}
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install system dependencies
+        if: ${{ steps.release_main.outputs.release_created }}
+        run: |
+          sudo apt-get install --yes cmake clang
+
+      - uses: Swatinem/rust-cache@v2
+        if: ${{ steps.release_main.outputs.release_created }}
+
+      - name: Publish sequintools
+        if: ${{ steps.release_main.outputs.release_created }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,8 @@
+{
+  "bootstrap-sha": "714ba4bae52aa6cc7d4609cba93110d326cb71c5",
+  "release-type": "rust",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "always-update": true,
+  "group-pull-request-title-pattern": "chore: release ${branch}"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
Add configuration for release-please to automate
releasing of the package and updating the
CHANGELOG.md.

We will not be able to test this until we create a
release, so there may be bugs that need to be
resolved.

Part of #106