### PR TITLE
ci: add rust cache to improve workflow speed

### DIFF
--- a/.github/workflows/test-and-lint-without-devcontainer.yml
+++ b/.github/workflows/test-and-lint-without-devcontainer.yml
@@ -30,6 +30,9 @@ jobs:
         toolchain: stable
         components: clippy, rustfmt
 
+    - name: Rust cache
+      uses: swatinem/rust-cache@v2
+
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
Use a smart cache for rust objects, which should
improve the speed of the workflow.

Part of #63