### PR TITLE
ci: fix main branch name

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
 
 name: release-please
 


### PR DESCRIPTION
We use 'main' for the main branch, not 'master'.

Part of #106