### PR TITLE
ci: add release-please-config.json file

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,6 @@
+{
+  "release-type": "rust",
+  "packages": {
+    ".": {}
+  }
+}


### PR DESCRIPTION
This file is required by the release-please GitHub
Action.

As we only have the single package in this
repository, we can use the default configuration.

Part of #106