### PR TITLE
chore: update dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"


### PR DESCRIPTION
Update dependabot commit messages so that they are
detected by release-please and included in release
notes.

Part of #106