### PR TITLE
ci: remove codecov from devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM mcr.microsoft.com/devcontainers/python:3.12-bookworm
+FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,9 +34,6 @@
 	"features": {
 		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {
 			"version": "latest"
-		},
-		"ghcr.io/devcontainers/features/rust:1.3.1": {
-			"version": "stable"
 		}
 	},
 	"postAttachCommand": "./.devcontainer/postAttachCommand.sh",

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,11 +3,5 @@
 
 set -e -x
 
-# Ensure we have the latest version of pip
-pip install --upgrade pip
-
-# Required to do manual pushes to codecov from inside our container.
-pip install --user -r ./.devcontainer/requirements.txt
-
 # Install container dependencies.
 cargo install cargo-tarpaulin@0.31.3

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,1 +1,0 @@
-codecov-cli==9.0.4


### PR DESCRIPTION
In guthub we no longer use the devcontainer for
testing, so we can remove the dependancy on
the codecov cli tool.

With this removed, we can now use a rust
devcontainer rather than a python one. Change
the Dockerfile to use the rust devcontainer and
remove rust from the features section of the
devcontainer.json file.

TEST=devcontainer stats && cargo test

Fixes: #118