### PR TITLE
fix: do not include component in the release tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,8 @@
 {
   "bootstrap-sha": "714ba4bae52aa6cc7d4609cba93110d326cb71c5",
   "release-type": "rust",
+  "include-component-in-tag": false,
+  "include-v-in-tag": true,
   "packages": {
     ".": {
       "release-type": "rust",


### PR DESCRIPTION
By default release-please wants to tag the release
with the component name. This is not necessary for
sequintools as this is a monorepo with only one
project in it.

This was also breaking our automation for creating
the docker sematic version tags.

Part of #106