### PR TITLE
ci: fix typo in release config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,12 +3,12 @@
   "release-type": "rust",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "pull-request-title-pattern": "chore: release v${version} ${branch}",
   "packages": {
     ".": {
       "release-type": "rust",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "group-pull-reqest-title-pattern": "chore: release v${version} ${branch}"
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
There was a typo 'reqest' in the config.

We only do single releases from this repo, so this
config was not taking effect anyway. Use
`pull-request-title-pattern` instead.

Part of #106