### PR TITLE
Allow the docker image to be used by nextflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,16 @@ COPY ./src ./src
 
 RUN cargo build --release
 
-# Stage 2: Create final Docker image with debain-slim.
+# Stage 2: Create final Docker image with debian-slim.
 FROM ghcr.io/linuxcontainers/debian-slim:12.5
+
+# Augment debian-slim with tools needed to run in nextflow
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y --force-yes \
+      procps=2:4.0.2-3 && \
+    apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy app and test data.
 COPY --from=builder /usr/sequins/target/release/sequintools /usr/local/bin/sequintools


### PR DESCRIPTION
Nextflow needs the `ps` command from `procps`.

Fixes: #129