### PR TITLE
chore: dependabot config for Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
       prefix: "fix(deps)"
       prefix-development: "chore(deps-dev)"
       include: "scope"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"


### PR DESCRIPTION
Add dependabot config to check our Dockerfile
dependencies once a week.

Fixes: #131