### PR TITLE
chore: fix dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "fix(deps)"
-      prefix-development: "chore(deps-dev)"
+      prefix: "fix"
+      prefix-development: "chore"
       include: "scope"
 
   - package-ecosystem: "docker"
@@ -14,6 +14,6 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "fix(deps)"
-      prefix-development: "chore(deps-dev)"
+      prefix: "fix"
+      prefix-development: "chore"
       include: "scope"


### PR DESCRIPTION
Fix the prefix used by dependabot in commit
messages so that the style matches conventional
commits.

Even though gitlint is now configured to ignore
dependabot commits, this will still look better in the commit log.