### PR TITLE
ci: bump minor version for a new feat

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,7 @@
     ".": {
       "release-type": "rust",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": false
     }
   }
 }


### PR DESCRIPTION
release-please has special configuration options
when the current version is < 1.0.0.

These options are controlled with the flags
`bump-minor-pre-major` and
`bump-patch-for-minor-pre-major`. In this case,
setting `bump-patch-for-minor-pre-major` to false
will ensure that any new features will bump the
minor version even if the current release is
< 1.0.0.