### PR TITLE
ci: configure concurrency group for docker builds

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -14,7 +14,7 @@ on:
     tags: [ "v*" ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.sha }}
 
 jobs:
   build:

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -13,6 +13,9 @@ on:
     ]
     tags: [ "v*" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2204


### PR DESCRIPTION
When we create a new release, the workflow is
triggered twice, once for the new tag and once
for the CL landing on main.

Use concurrency group to ensure that only one
docker build runs at a time, and hopefully the
second run will use cached artifacts.

Fixes #142