### PR TITLE
feat: interpret bedcov max depth 0 as no limit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,8 @@ pub struct BedcovArgs {
     #[arg(short = 'f', long = "flank", default_value_t = 0)]
     flank: i32,
 
-    /// max per-file depth; avoids excessive memory usage
+    /// max per-file depth; avoids excessive memory usage. Passing zero sets it
+    /// to the highest possible value, effectively removing the depth limit.
     #[arg(short = 'd', long = "max-depth", default_value_t = 8_000)]
     max_depth: u32,
 


### PR DESCRIPTION
If a user passes `--bedcov-max-depth 0` to the `bedcov` subcommand, it
is now interpreted as no limit on the maximum depth of coverage. This
mimics how the `--max-depth` option for `samtools mpileup` works.
