### PR TITLE
fix: do not apply a depth limit when calculating mean in calibrate

### DIFF
--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -69,11 +69,6 @@ use std::io;
 use std::process::exit;
 use std::vec::Vec;
 
-// Defines the max depth for pileup operations. Previously this was not defined
-// in calls to `pileup` so this represents the default to make calls backward
-// compatible.
-const PILEUP_MAX_DEPTH: u32 = 8_000;
-
 /// Calibrates sequin coverage based on the provided arguments.
 ///
 /// This function serves as the main entry point for calibration operations. It determines the
@@ -211,7 +206,7 @@ pub fn calibrate_by_standard_coverage(args: CalibrateArgs) -> Result<()> {
         let coverage = args.fold_coverage as f64;
 
         for region in &regions {
-            let depth = mean_depth(&mut bam, region, args.flank, 10, PILEUP_MAX_DEPTH)?.mean;
+            let depth = mean_depth(&mut bam, region, args.flank, 10, 0)?.mean;
             println!(
                 "{}:{}-{} {} {}",
                 region.contig,
@@ -880,7 +875,7 @@ mod tests {
             },
             0,
             0,
-            PILEUP_MAX_DEPTH,
+            0,
         );
         assert_eq!(result.unwrap().mean, 33.95);
     }
@@ -894,9 +889,7 @@ mod tests {
             end: 199,
             name: "reg2".to_owned(),
         };
-        let result = mean_depth(&mut bam, &region, 0, 0, PILEUP_MAX_DEPTH)
-            .unwrap()
-            .mean;
+        let result = mean_depth(&mut bam, &region, 0, 0, 0).unwrap().mean;
         assert_eq!(result, 35.25);
     }
 
@@ -909,9 +902,7 @@ mod tests {
             end: 199,
             name: "reg2".to_owned(),
         };
-        let result = mean_depth(&mut bam, &region, 0, 10, PILEUP_MAX_DEPTH)
-            .unwrap()
-            .mean;
+        let result = mean_depth(&mut bam, &region, 0, 10, 0).unwrap().mean;
         assert_eq!(result, 0.0);
     }
 


### PR DESCRIPTION
When calibrating the mean depth for a region in the `calibrate`
subcommand, we were using a default maximum depth of 8,000 (which is
what htslib uses). If the coverage exceeds this, the downsampling is
incorrect. This commit changes the behaviour to always use the maximum
max depth possible (u32::MAX). This ensures the user will always get a
correctly calibrated BAM file.
