### PR TITLE
ci: use the organization secret for sequins-bot

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release_main
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.SEQUINS_BOT_ACCESS_TOKEN }}
           manifest-file: .release-please-manifest.json
 
       - name: Install stable toolchain


### PR DESCRIPTION
We have an organizational secret for the
sequins-bot access token that we should use
instead of the repository specific token.