### PR TITLE
ci: change release-please to run weekly

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # Time is in UTC, this should run every Wednesday at 06:00 Sydney time
+    - cron: '0 19 * * 2'
   workflow_dispatch:
 
 name: release-please


### PR DESCRIPTION
We don't need to run release-please on every
commit. We can run it weekly instead and
establish a weekly release cadence.

Run it on Wednesdays at 06:00 Sydney time so we
can review and release on Wednesdays.