### PR TITLE
fix: legacy cache api

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -35,6 +35,8 @@ jobs:
 
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
 
       - name: Docker metadata
         id: meta

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: latest
+          version: v3.10.0
 
       - name: Docker metadata
         id: meta


### PR DESCRIPTION
Outdated tools that only support the legacy GitHub Cache service API v1.

Use suggested workaround to fix it.

#183