### PR TITLE
feat: adjust calibration algorithm for standard coverage

### DIFF
--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1155,4 +1155,27 @@ mod tests {
 
         // TODO: check the output BAM
     }
+
+    #[test]
+    fn test_subsample() {
+        let mut rng = Pcg32::seed_from_u64(42);
+        let mut hash = HashMap::new();
+        let mut record = bam::Record::new();
+        record.set_qname(b"read1");
+        record.set_pos(100);
+        record.set_mpos(200);
+
+        let result = subsample(&record, &mut hash, 1.0, &mut rng);
+        assert!(result);
+
+        // Test with a different threshold
+        let result = subsample(&record, &mut hash, 0.0, &mut rng);
+        assert!(result);
+
+        let mut hash = HashMap::new();
+        record.set_pos(200);
+        record.set_mpos(100);
+        let result = subsample(&record, &mut hash, 1.0, &mut rng);
+        assert!(!result);
+    }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -58,7 +58,7 @@ use crate::CalibrateArgs;
 use anyhow::{Context, Result};
 use rand::seq::IteratorRandom;
 use rand::{Rng, SeedableRng};
-use rand_pcg::{Lcg64Xsh32, Pcg32};
+use rand_pcg::Pcg32;
 use rust_htslib::{bam, bam::Read};
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -311,7 +311,7 @@ fn subsample(
     record: &bam::Record,
     hash: &mut HashMap<String, bool>,
     threshold: f64,
-    rng: &mut Lcg64Xsh32,
+    rng: &mut Pcg32,
 ) -> bool {
     let qname = String::from_utf8(record.qname().to_vec()).unwrap();
     match hash.get(&qname) {

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1168,14 +1168,50 @@ mod tests {
         let result = subsample(&record, &mut hash, 1.0, &mut rng);
         assert!(result);
 
-        // Test with a different threshold
+        // Test with key added by first subsample
         let result = subsample(&record, &mut hash, 0.0, &mut rng);
         assert!(result);
+    }
 
+    #[test]
+    fn test_subsample_reject_read() {
+        let mut rng = Pcg32::seed_from_u64(42);
         let mut hash = HashMap::new();
+        let mut record = bam::Record::new();
+        record.set_qname(b"read1");
+        record.set_pos(100);
+        record.set_mpos(200);
+
+        // Test with a different threshold
+        let result = subsample(&record, &mut hash, 0.0, &mut rng);
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_subsample_mate_before_read() {
+        let mut rng = Pcg32::seed_from_u64(42);
+        let mut hash = HashMap::new();
+        let mut record = bam::Record::new();
+        record.set_qname(b"read1");
         record.set_pos(200);
         record.set_mpos(100);
         let result = subsample(&record, &mut hash, 1.0, &mut rng);
         assert!(!result);
+    }
+
+    #[test]
+    fn test_subsample_read_in_hash() {
+        let mut rng = Pcg32::seed_from_u64(42);
+
+        let mut hash = HashMap::new();
+        hash.insert("read1".to_string(), true);
+
+        let mut record = bam::Record::new();
+        record.set_qname(b"read1");
+        record.set_pos(100);
+        record.set_mpos(200);
+
+        let result = subsample(&record, &mut hash, 1.0, &mut rng);
+        assert!(result);
     }
 }


### PR DESCRIPTION
When calibrating to a standard coverage, the mean coverage was
consistently higher than expected. This was due to an error in the way
reads were selected for keeping or excluding resulting is some
singletons being mistakenly retained. This commit fixes this so that
both pairs of a fragment are always retained, and the resulting mean
coverage is closer to the requested coverage.
