### PR TITLE
chore: run release please on config change

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -4,4 +4,4 @@
 set -e -x
 
 # Install container dependencies.
-cargo install cargo-tarpaulin@0.32.5
+cargo install cargo-tarpaulin@0.31.3

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -4,4 +4,4 @@
 set -e -x
 
 # Install container dependencies.
-cargo install cargo-tarpaulin@0.31.3
+cargo install cargo-tarpaulin@0.32.5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,12 @@ on:
     # Time is in UTC, this should run every Wednesday at 06:00 Sydney time
     - cron: '0 19 * * 2'
   workflow_dispatch:
+  push:
+      branches:
+        - main
+      paths:
+        - "release-please-config.json"
+        - ".release-please-manifest.json"
 
 name: release-please
 


### PR DESCRIPTION
When the release please config or manifest
changes, we need to run release please to
actually create the release.