### PR TITLE
chore: latest version of buildx is v0.23.0

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v3
         with:
-          version: v3.10.0
+          version: v0.23.0
 
       - name: Docker metadata
         id: meta


### PR DESCRIPTION
Update docker build workflow to use the current
latest version of buildx.