### PR TITLE
feat: use multi threads when reading bams

### DIFF
--- a/src/bedcov.rs
+++ b/src/bedcov.rs
@@ -2,7 +2,7 @@ use crate::calibrate::{mean_depth, DepthResult};
 use crate::region::{load_from_bed, Region};
 use crate::BedcovArgs;
 use anyhow::Result;
-use rust_htslib::bam;
+use rust_htslib::bam::{self, Read};
 use std::fs::File;
 use std::io::{self, Write};
 
@@ -53,6 +53,10 @@ fn bedcov_report<W: Write>(
     dest: W,
 ) -> Result<()> {
     let mut bam = bam::IndexedReader::from_path(bam_path)?;
+    let ncpus = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+    bam.set_threads(ncpus)?;
     let regions: Vec<Region> = load_from_bed(&mut io::BufReader::new(File::open(bed_path)?))?;
 
     let mut wtr = csv::Writer::from_writer(dest);

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -299,8 +299,7 @@ fn write_summary_report(
         result.calibrated_coverage = bam
             .as_mut()
             .map(|b| mean_depth(b, region, flank, args.min_mapq, PILEUP_MAX_DEPTH))
-            .transpose()
-            .with_context(|| "Failed to calculate mean depth")?
+            .transpose()?
             .map(|d| d.mean)
             .unwrap_or(0.0);
 
@@ -1038,6 +1037,20 @@ mod tests {
             },
         ];
         let result = write_summary_report(&mut calibration_results, &args);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_write_summary_report_with_sample() {
+        let mut args = mock_calibrate_args(true, false);
+        args.summary_report = Some(
+            NamedTempFile::new()
+                .unwrap()
+                .path()
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let result = write_summary_report(&mut [], &args);
         assert!(result.is_ok());
     }
 

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1124,6 +1124,21 @@ mod tests {
     }
 
     #[test]
+    fn test_write_summary_report_missing_output() {
+        let mut args = mock_calibrate_args(false, false);
+        args.output = Some("does-not-exist".to_string());
+        args.summary_report = Some(
+            NamedTempFile::new()
+                .unwrap()
+                .path()
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let result = write_summary_report(&mut [], &args);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_window_starts() {
         let mut bam = bam::IndexedReader::from_path(TEST_BAM_PATH).unwrap();
         let region = Region {
@@ -1455,5 +1470,13 @@ mod tests {
         args.experimental = true;
         let result = calibrate(args);
         assert!(result.is_err(), "{:?}", result);
+    }
+
+    #[test]
+    fn test_calibrate_by_standard_coverage_missing_bam() {
+        let mut args = mock_calibrate_args(false, true);
+        args.path = "does-not-exist".to_string();
+        let result = calibrate_by_standard_coverage(args);
+        assert!(result.is_err());
     }
 }

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -285,7 +285,10 @@ fn write_summary_report(
         .map(IndexedReader::from_path)
         .transpose()
         .with_context(|| "Failed to open BAM file")?;
-    bam.as_mut().map(|b| b.set_threads(ncpus));
+    if let Some(b) = bam.as_mut() {
+        b.set_threads(ncpus)
+            .with_context(|| "Failed to set thread count for BAM reader")?;
+    }
     let flank = if args.sample_bed.is_some() {
         0
     } else {

--- a/src/region.rs
+++ b/src/region.rs
@@ -188,7 +188,7 @@ mod tests {
     struct ErrorReader;
     impl Read for ErrorReader {
         fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
-            Err(io::Error::new(io::ErrorKind::Other, "bad read"))
+            Err(io::Error::other("bad read"))
         }
     }
     #[test]


### PR DESCRIPTION
Sets the thread count to the number of available CPUs when reading BAM
files. Depending on the number of CPUs available, this can significantly
improve the run time of the calibrated and bedcov commands.
