### PR TITLE
ci: same rust version in devcontainer and workflows

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
+FROM mcr.microsoft.com/devcontainers/rust:1.0.23-1-bookworm
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/.github/workflows/test-and-lint-without-devcontainer.yml
+++ b/.github/workflows/test-and-lint-without-devcontainer.yml
@@ -25,9 +25,8 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@1.86.0
       with:
-        toolchain: stable
         components: clippy, rustfmt
 
     - name: Rust cache


### PR DESCRIPTION
This updates the devcontainer to use a more precisely pinned version of
the container, which also pins the Rust version, and updates the action
that runs outside of the devcontainer to use the same Rust version.

`actions-rs/toolchain` is replaced by `dtolnay/rust-toolchain` as the
former is archived and unmaintained, while the latter is under active
maintanance.

Closes #195 
