### PR TITLE
feat: allow CRAM input files

### DIFF
--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -221,6 +221,9 @@ pub fn calibrate_by_standard_coverage(args: CalibrateArgs) -> Result<()> {
         .map(|n| n.get())
         .unwrap_or(1);
     bam.set_threads(ncpus)?;
+    if let Some(reference) = args.reference.as_ref() {
+        bam.set_reference(reference)?;
+    }
     let header = bam::Header::from_template(bam.header());
     let mut out = match &args.output {
         Some(path) => bam::Writer::from_path(path, &header, bam::Format::Bam)?,
@@ -288,7 +291,11 @@ fn write_summary_report(
     if let Some(b) = bam.as_mut() {
         b.set_threads(ncpus)
             .with_context(|| "Failed to set thread count for BAM reader")?;
+        if let Some(reference) = args.reference.as_ref() {
+            b.set_reference(reference)?;
+        }
     }
+
     let flank = if args.sample_bed.is_some() {
         0
     } else {
@@ -677,6 +684,9 @@ fn calibrate_by_sample_coverage(args: CalibrateArgs) -> Result<()> {
         .map(|n| n.get())
         .unwrap_or(1);
     bam.set_threads(ncpus)?;
+    if let Some(reference) = args.reference.as_ref() {
+        bam.set_reference(reference)?;
+    }
     {
         let header = bam::Header::from_template(bam.header());
         let mut out = match &args.output {
@@ -790,7 +800,7 @@ fn calibrate_regions(
             let window_end = window_beg + args.window_size - 1;
 
             // We are always keeping both reads from paired-end data, so
-            // ever  ytime we select a read to keep we are actually keeping two
+            // every time we select a read to keep we are actually keeping two
             // reads. This results in higher coverage in the calibrated sequin
             // regions compared to the sample region. I'm dividing by 2 as a
             // quick and dirty adjustment; it gives a sequin coverage that is
@@ -1002,6 +1012,7 @@ mod tests {
             exclude_uncalibrated_reads: false,
             experimental: false,
             summary_report: None,
+            reference: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,10 @@ pub struct CalibrateArgs {
     #[arg(short, long)]
     output: Option<String>,
 
+    /// Reference sequence FASTA file. Used when input is CRAM format.
+    #[arg(short = 'T', long = "reference")]
+    reference: Option<String>,
+
     path: String,
 }
 
@@ -82,6 +86,10 @@ pub struct BedcovArgs {
     /// to the highest possible value, effectively removing the depth limit.
     #[arg(short = 'd', long = "max-depth", default_value_t = 8_000)]
     max_depth: u32,
+
+    /// Reference sequence FASTA file. Used when input is CRAM format.
+    #[arg(short = 'T', long = "reference")]
+    reference: Option<String>,
 
     bed_path: String,
     bam_path: String,


### PR DESCRIPTION
This adds a `--reference` option to both calibrate and bedcov commands.
This is required to handle CRAM input files. It's not technically a
requirement with CRAM files, but in most cases the automatic download of
reference files will fail unless the reference is explicitly provided.
