### PR TITLE
fix: reduce crate size to complie with crates.io restrictions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ publish = true
 description = "A suite of tools for manipulating and reporting on NGS data that has sequins added to the sample."
 readme = "README.md"
 repository = "https://github.com/sequinsbio/sequintools"
+exclude = ["example/*"]
 
 [[bin]]
 name = "sequintools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ publish = true
 description = "A suite of tools for manipulating and reporting on NGS data that has sequins added to the sample."
 readme = "README.md"
 repository = "https://github.com/sequinsbio/sequintools"
-exclude = ["example/*"]
+exclude = ["example"]
 
 [[bin]]
 name = "sequintools"


### PR DESCRIPTION
crates.io has a size limit of 10MB per crate. The example directory is
almost 10MB by itself. This commit updates Cargo.toml to exclude the
example directory from the crate so it can successfully be uploaded to
crates.io.
