### PR TITLE
fix: abort when summary requested without index

### DIFF
--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -127,6 +127,9 @@ const PILEUP_MAX_DEPTH: u32 = i32::MAX as u32;
 /// }
 /// ```
 pub fn calibrate(args: CalibrateArgs) -> Result<()> {
+    if args.summary_report.is_some() && !args.write_index {
+        bail!("Cannot write summary report without writing BAM index. Set --write-index to true.");
+    }
     if args.experimental {
         return calibrate_by_sample_coverage(args);
     }


### PR DESCRIPTION
To create the summary report with `--summary-report` in the calibrate
command, we need to index the output alignment file. This commit adds a
check that the `--write-index` option is also provided with
`--summary-report` and exits if not.
