### PR TITLE
feat: add support for CRAM output

### DIFF
--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -1552,4 +1552,33 @@ mod tests {
         let result = calibrate_by_standard_coverage(args);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_calibrated_by_standard_coverage_cram_output() {
+        let mut args = mock_calibrate_args(true, true);
+        args.path = TEST_CRAM_PATH.to_string();
+        args.reference = Some(TEST_CRAM_REF_PATH.to_string());
+        args.bed = TEST_CRAM_BED_PATH.to_string();
+        args.cram = true;
+        let out_path = args.output.clone().unwrap();
+        let result = calibrate_by_standard_coverage(args);
+        assert!(result.is_ok());
+        let metadata = std::fs::metadata(&out_path).unwrap();
+        assert!(metadata.len() > 0, "Output BAM file should not be empty");
+    }
+
+    #[test]
+    fn test_calibrate_by_sample_coverage_cram_output() {
+        let mut args = mock_calibrate_args(true, true);
+        args.path = TEST_CRAM_PATH.to_string();
+        args.reference = Some(TEST_CRAM_REF_PATH.to_string());
+        args.bed = TEST_CRAM_BED_PATH.to_string();
+        args.sample_bed = Some(TEST_CRAM_BED_PATH.to_string());
+        args.cram = true;
+        let out_path = args.output.clone().unwrap();
+        let result = calibrate_by_sample_coverage(args);
+        assert!(result.is_ok());
+        let metadata = std::fs::metadata(&out_path).unwrap();
+        assert!(metadata.len() > 0, "Output BAM file should not be empty");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,10 @@ pub struct CalibrateArgs {
     #[arg(short = 'T', long = "reference")]
     reference: Option<String>,
 
+    /// Write output as CRAM (requires --reference)
+    #[arg(short = 'C', long = "cram", default_value_t = false)]
+    cram: bool,
+
     path: String,
 }
 


### PR DESCRIPTION
This adds support for CRAM output with the `-C`, `--cram` arguments.

Closes #199
