### PR TITLE
fix(ci): add musl dependencies to build

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -27,6 +27,12 @@ jobs:
           targets: ${{ matrix.target }}
           components: clippy, rustfmt
 
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools musl-dev
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Build binary


### PR DESCRIPTION
When attempting to build for the target `x86_64-unknown-linux-musl` on
ubuntu, we need to also install some extra musl build dependencies.
