### PR TITLE
chore: remove RUSTSEC-2024-0421 advisory check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ path = "src/main.rs"
 clap = { version = "4.5.41", features = ["derive"] }
 rand = "0.9.1"
 rand_pcg = "0.9.0"
-# When uprevving htslib, check if we can remove the advisory ignore in the
-# deny.toml file for the idna crate.
 rust-htslib = "0.50.0"
 anyhow = "1.0.98"
 csv = "1.3.1"

--- a/deny.toml
+++ b/deny.toml
@@ -64,7 +64,6 @@ feature-depth = 1
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 ignore = [
-    { id = "RUSTSEC-2024-0421", reason = "Need htslib to uprev idna" },
     #"RUSTSEC-0000-0000",
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
This advisory was being ignored while waiting for rust-htslib to update
dependencies. rust-htslib has merged the PR with this fix, so ignoring
the advisory is no longer necessary.

Closes #70
