### PR TITLE
ci: add musl target when building binaries

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install musl target
         if: matrix.target == 'x86_64-unknown-linux-musl'
-        run: rustup target add x86_64-unknown-linux-musl
+        run: rustup target add ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -32,6 +32,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y musl-tools musl-dev
 
+      - name: Install musl target
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: rustup target add x86_64-unknown-linux-musl
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Build binary


### PR DESCRIPTION
When building release binaries, add the rust musl target on Linux.
