### PR TITLE
feat: add samtools to docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.env
+target
+testdata
+example

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
   apt-get --no-install-recommends install -y \
   procps=2:4.0.4-9 \
   samtools=1.21-1 && \
-  apt-get clean autoclean && \
+  apt-get clean && \
   apt-get autoremove -y && \
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ FROM debian:13.0-slim
 # Augment debian-slim with tools needed to run in nextflow
 RUN apt-get update && \
   apt-get --no-install-recommends install -y \
-  procps=2:4.0.4-9 && \
+  procps=2:4.0.4-9 \
+  samtools=1.21-1 && \
   apt-get clean autoclean && \
   apt-get autoremove -y && \
   rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
It's useful to have a copy of `samtools` in the `sequintools` container
as it can be used to manipulate the output BAM file in many ways.
