### PR TITLE
refactor: create a library that the binary depends on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,7 +785,7 @@ dependencies = [
  "linear-map",
  "newtype_derive",
  "regex",
- "thiserror 2.0.3",
+ "thiserror 2.0.16",
  "url",
 ]
 
@@ -846,6 +846,7 @@ dependencies = [
  "rand_pcg",
  "rust-htslib",
  "tempfile",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -948,11 +949,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -968,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rand_pcg = "0.9.0"
 rust-htslib = "0.50.0"
 anyhow = "1.0.99"
 csv = "1.3.1"
+thiserror = "2.0.16"
 
 [dev-dependencies]
 tempfile = "3.21.0"

--- a/src/bedcov.rs
+++ b/src/bedcov.rs
@@ -1,8 +1,8 @@
 use crate::calibrate::{mean_depth, DepthResult};
-use crate::region::{load_from_bed, Region};
 use crate::BedcovArgs;
 use anyhow::Result;
 use rust_htslib::bam::{self, Read};
+use sequintools::region::{load_from_bed, Region};
 use std::fs::File;
 use std::io::{self, Write};
 

--- a/src/calibrate.rs
+++ b/src/calibrate.rs
@@ -54,7 +54,6 @@
 //!
 //! Ensure input BAM files are properly indexed before calibration.
 //! The module assumes 0-based coordinates in BED files.
-use crate::region::{self, Region};
 use crate::CalibrateArgs;
 use anyhow::{bail, Context, Result};
 use rand::seq::IteratorRandom;
@@ -62,6 +61,7 @@ use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg32;
 use rust_htslib::bam::{IndexedReader, Writer};
 use rust_htslib::{bam, bam::Read};
+use sequintools::region::{self, Region};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,7 +6,7 @@ pub enum Error {
     BamFileNotFound,
     #[error("Invalid region specified")]
     InvalidRegion,
-    #[error("A unknown error occurred: {0}")]
+    #[error("An unknown error occurred: {0}")]
     Unknown(String),
 
     #[error("IO error: {0}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("BAM file not found")]
+    BamFileNotFound,
+    #[error("Invalid region specified")]
+    InvalidRegion,
+    #[error("A unknown error occurred: {0}")]
+    Unknown(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("HTSlib error: {0}")]
+    Hts(#[from] rust_htslib::errors::Error),
+
+    #[error("invalid BED record: {msg}")]
+    BedInvalidRecord { msg: String },
+
+    #[error("bedcov error: {msg}")]
+    Bedcov { msg: String },
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod errors;
+pub use errors::Result;
+pub mod region;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use clap::{Args, Parser, Subcommand};
 
 mod bedcov;
 mod calibrate;
-mod region;
 
 #[derive(Parser, Debug)]
 #[clap(version)]

--- a/src/region.rs
+++ b/src/region.rs
@@ -17,7 +17,7 @@
 //! ## Tests
 //!
 //! Contains unit tests for verifying the functionality of the `Region` struct and the `load_from_bed` function.
-use anyhow::{bail, Context, Result};
+use crate::errors::{Error, Result};
 use std::fmt;
 use std::io::Read;
 
@@ -61,26 +61,28 @@ pub fn load_from_bed<R: Read>(reader: &mut R) -> Result<Vec<Region>> {
     for (i, line) in contents.lines().enumerate() {
         let bits: Vec<&str> = line.split_whitespace().collect();
         let [contig, beg_str, end_str, name, ..] = bits[..] else {
-            bail!(
-                "Incorrect number of columns detected, expected >= 4 found {} (line = {})",
-                bits.len(),
-                i + 1
-            )
+            return Err(Error::BedInvalidRecord {
+                msg: format!(
+                    "Incorrect number of columns detected, expected >= 4 found {} (line = {})",
+                    bits.len(),
+                    i + 1
+                ),
+            });
         };
 
-        let beg: u64 = beg_str.parse().with_context(|| {
-            format!(
+        let beg: u64 = beg_str.parse().map_err(|_| Error::BedInvalidRecord {
+            msg: format!(
                 "Beg column is not an integer: is {} (line = {})",
                 bits[1],
                 i + 1
-            )
+            ),
         })?;
-        let end: u64 = end_str.parse().with_context(|| {
-            format!(
+        let end: u64 = end_str.parse().map_err(|_| Error::BedInvalidRecord {
+            msg: format!(
                 "End column is not an integer: is {} (line = {})",
                 bits[2],
                 i + 1
-            )
+            ),
         })?;
         result.push(Region {
             contig: contig.to_owned(),


### PR DESCRIPTION
This commit creates a library crate along side the main binary crate.
Within the library, proper error types are used and the use of `anyhow`
is eliminated. The `region` module has been placed inside the new
library.

This is the first stage of a multi-stage refactoring with the aim to
improve the code structure to improve our ability to test code and allow
the introduction of a much faster coverage calculation algorithm.
