### PR TITLE
chore: add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.89.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Adding this file is the proper way to ensure that the same version of
Rust/Cargo is used throughout the project (build, CI etc) and by all
contributors.
