### PR TITLE
ci: add RUSTSEC-2025-0058 exception

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -68,6 +68,7 @@ ignore = [
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+    { id = "RUSTSEC-2025-0058", reason = "dependency of rust_htslib" },
 ] # The path where the advisory databases are cloned/fetched into
 #db-path = "$CARGO_HOME/advisory-dbs"
 # The url(s) of the advisory databases to use


### PR DESCRIPTION
RUSTSEC-2025-0058: The `custom_derive` crate is no longer actively maintained.

This is a dependency of `rust-htslib`. We obviously can't remove this dependency, so adding an exception to cargo deny until it's updated upsteram.

Link: https://rustsec.org/advisories/RUSTSEC-2025-0058