### PR TITLE
ci: update from tarpaulin to llvm-cov for test coverage

### DIFF
--- a/.github/workflows/test-and-lint-without-devcontainer.yml
+++ b/.github/workflows/test-and-lint-without-devcontainer.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@1.86.0
+      uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy, rustfmt
 
@@ -37,24 +37,23 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake clang
 
-    - name: Install cargo-tarpaulin
-      uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-tarpaulin
-        version: latest
-
-    - name: Run cargo-tarpaulin
-      run: cargo tarpaulin --verbose --all-features --out xml
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: unittest
-        name: job-name-${{ github.run_id }}
-        verbose: true
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
 
     - name: Run format tests and lints
       run: |
         cargo fmt --all -- --check
         cargo clippy --all --all-features --tests -- -D warnings
+
+    - name: Generate test coverage
+      run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+
+    - name: Upload coverage to Codecov
+      if: github.actor != 'dependabot[bot]'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: unittest
+        name: job-name-${{ github.run_id }}
+        verbose: true
+        fail_ci_if_error: true


### PR DESCRIPTION
This commit changes the GitHub Action that builds test coverage reports from using tarpaulin to llvm-cov. tarpaulin can produce many false positives (in terms of lines uncovered by tests), which in turn can cause patch coverage to be very deceptive. llvm-cov is reported as being more accurate and faster; all current advice seems to point to using llvm-cov over tarpaulin.