### PR TITLE
feat: update cli version message

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    let version = env::var("CARGO_PKG_VERSION").unwrap();
+
+    let git_output = Command::new("git")
+        .args(["describe", "--tags", "--dirty", "--always"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_else(|| version.clone());
+
+    println!("cargo:rustc-env=GIT_VERSION={}", git_output.trim());
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::io::BufReader;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
-#[clap(version)]
+#[clap(version = env!("GIT_VERSION"))]
 pub struct App {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
Include `git describe` in version message produced with `sequintools --version`. This will now include how many commits from the last tag and the commit hash used to build the binary. This can be vital in reproducing bugs or understanding inconsistencies in output. If built from latest commit, it may be many commits since the last tag, so just using this is not helpful.