### PR TITLE
ci: remove .git from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 .env
 target
 testdata

--- a/build.rs
+++ b/build.rs
@@ -13,5 +13,5 @@ fn main() {
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| version.clone());
 
-    println!("cargo:rustc-env=GIT_VERSION={}", git_output.trim());
+    println!("cargo:rustc-env=GIT_VERSION={}", git_output);
 }

--- a/build.rs
+++ b/build.rs
@@ -9,8 +9,14 @@ fn main() {
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
+        .and_then(|s| {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        })
         .unwrap_or_else(|| version.clone());
 
     println!("cargo:rustc-env=GIT_VERSION={}", git_output);

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,8 @@ fn main() {
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
         .unwrap_or_else(|| version.clone());
 
     println!("cargo:rustc-env=GIT_VERSION={}", git_output.trim());


### PR DESCRIPTION
A previous commit updated the way the version is detected in a way that requires the git directory (`.git`). This was not being sent to the docker daemon when building containers causing a failure. This commit removes the git directory from the `.dockerignore` file and makes the build function more robust when `.git` is missing.