### PR TITLE
fix: add build.rs to docker build

### DIFF
--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -57,6 +57,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute version string
+        id: version
+        run: |
+          if git describe --tags --dirty --always > /dev/null 2>&1; then
+            V=$(git describe --tags --dirty --always)
+          else
+            V=${GITHUB_SHA::7}
+          fi
+          echo "git_version=$V" >> $GITHUB_OUTPUT
+          echo "Computed version: $V"
+
       - name: Build container
         uses: docker/build-push-action@v6
         with:
@@ -66,3 +77,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            SEQUINTOOLS_GIT_VERSION=${{ steps.version.outputs.git_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /usr/sequins
 
+# Accept version string from build context (fallback handled in build.rs)
+ARG SEQUINTOOLS_GIT_VERSION
+ENV SEQUINTOOLS_GIT_VERSION=${SEQUINTOOLS_GIT_VERSION}
+
 # Copy the Cargo.toml and Cargo.lock files first
 COPY ./Cargo.toml ./Cargo.toml
 COPY ./Cargo.lock ./Cargo.lock
 COPY ./build.rs ./build.rs
-COPY ./.git ./.git
 COPY ./src ./src
 
-RUN cargo build --release
+# Build with locked deps; build.rs will embed version using SEQUINTOOLS_GIT_VERSION if provided
+RUN cargo build --locked --release
 
 # Stage 2: Create final Docker image with debian-slim.
 FROM debian:13.0-slim

--- a/build.rs
+++ b/build.rs
@@ -2,22 +2,26 @@ use std::env;
 use std::process::Command;
 
 fn main() {
-    let version = env::var("CARGO_PKG_VERSION").unwrap();
-
-    let git_output = Command::new("git")
-        .args(["describe", "--tags", "--dirty", "--always"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .and_then(|s| {
-            let trimmed = s.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            }
-        })
-        .unwrap_or_else(|| version.clone());
-
-    println!("cargo:rustc-env=GIT_VERSION={}", git_output);
+    let git_version = match env::var("SEQUINTOOLS_GIT_VERSION") {
+        Ok(version) => version,
+        Err(_) => {
+            let version = env::var("CARGO_PKG_VERSION").unwrap();
+            let git_output = Command::new("git")
+                .args(["describe", "--tags", "--dirty", "--always"])
+                .output()
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .and_then(|s| {
+                    let trimmed = s.trim();
+                    if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    }
+                })
+                .unwrap_or_else(|| version.clone());
+            git_output
+        }
+    };
+    println!("cargo:rustc-env=GIT_VERSION={}", git_version);
 }


### PR DESCRIPTION
~Add `build.rs` and `.git` to the docker build. These files are required to correctly set the version information in the binary. Without them, building the docker container fails.~
Updates the dockerfile and GitHub Action to provide the git derived version string. A previous commit added this logic to the `build.rs` file, but the `.git` directory is not added to the docker build causing it to fail. It's not recommended to add `.git` to a docker build, so this adds an ARG to the docker files and sets it it the action.