### PR TITLE
chore: update rust to 1.90.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Updating Rust tool chain to latest 1.90.0 version.