### PR TITLE
chore: set dependabot schedule to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
     commit-message:
       prefix: "chore"
       prefix-development: "chore"
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
     commit-message:
       prefix: "chore"
       prefix-development: "chore"


### PR DESCRIPTION
Change dependabot's schedule to quarterly. Real updates to this project are infrequent, and it just creates extra work to have weekly deps updates.