### PR TITLE
revert: chore(deps): bump lukemathwalker/cargo-chef

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # lukemathwalker/cargo-chef:0.1.73-rust-1.93.0
-FROM lukemathwalker/cargo-chef@sha256:d5a1cca12f21de999e5b221b5c6ff5635080f4b8d5e58053241ff169e0fc60f6 AS chef
+FROM lukemathwalker/cargo-chef@sha256:9e564338159930326c71b6c3df9ed5e5b60b0437b84861c6bb6767b1964a0fd4 AS chef
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
This update is breaking the docker build, so reverting until we have time to figure out what's going wrong and correct.

Refs: d5a1cc, 6b5efa3bb2c2f1f2ee8f032cee93eb8848718c76