### PR TITLE
ci: add cooldown to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -17,3 +19,5 @@ updates:
       prefix: "chore"
       prefix-development: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add a 7 day cooldown period for all Cargo and Docker dependency updates. This prevents updating any package released less than seven days ago to help avoid nasty surprises.