### PR TITLE
ci: add docker build action

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,23 @@
+name: Build Docker Image
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - Cargo.toml
+      - Cargo.lock
+      - build.rs
+      - src/**
+jobs:
+  build:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup docker buildx
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: Build Docker Image
+        uses: useblacksmith/build-push-action@v2
+        with:
+          push: false


### PR DESCRIPTION
Add an action to build the docker image when pull requests modify the Dockerfile or any file it depends on. This does not push the image, it only checks for a successful build.