### PR TITLE
chore(calibrate): hide deprecated summary report option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,20 +124,6 @@ sequintools calibrate \
     example/example.bam
 ```
 
-You can also create a summary file with before and after coverage using the
-`--summary-report` option:
-
-```sh
-sequintools calibrate \
-    -b example/resources/sequin_regions.chrQ_mirror.bed \
-    -H example/resources/sequin_regions.hg38.bed \
-    -o calibrated.bam \
-    --summary-report calibrate.summary.csv \
-    --write-index \
-    --exclude-uncalibrated-reads \
-    example/example.bam
-```
-
 ### `bedcov`
 
 The `bedcov` command collects statistics from a BAM file for regions in a BED

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,10 +53,9 @@ pub struct CalibrateArgs {
     #[arg(short, long)]
     bed: PathBuf,
 
-    /// File to write summary report (CSV). Will contain uncalibrated, target
-    /// and calibrated mean coverage of each sequin region. Only created when
-    /// `--sample-bed` is provided.
-    #[arg(long)]
+    // Kept temporarily so older commands that still pass --summary-report do not fail.
+    // The summary report output is no longer implemented.
+    #[arg(long, hide = true)]
     summary_report: Option<PathBuf>,
 
     /// Change to experimental sample profile matching - unsuitable for
@@ -127,7 +126,15 @@ impl From<BedcovArgs> for sequintools::coverage::BedcovArgs {
 fn main() -> Result<()> {
     let args = App::parse();
     match args.command {
-        Commands::Calibrate(args) => run_calibrate(&args)?,
+        Commands::Calibrate(args) => {
+            if args.summary_report.is_some() {
+                eprintln!(
+                    "Warning: --summary-report is deprecated and ignored. \
+                    Use the bedcov command for coverage information."
+                );
+            }        
+            run_calibrate(&args)?
+        },
         Commands::Bedcov(args) => sequintools::coverage::run(&args.into())?,
     };
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,9 +132,9 @@ fn main() -> Result<()> {
                     "Warning: --summary-report is deprecated and ignored. \
                     Use the bedcov command for coverage information."
                 );
-            }        
+            }
             run_calibrate(&args)?
-        },
+        }
         Commands::Bedcov(args) => sequintools::coverage::run(&args.into())?,
     };
     Ok(())

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -248,3 +248,34 @@ fn test_calibrate_cram_input_output() {
     let record_count = reader.records().count();
     assert_eq!(record_count, 4356);
 }
+
+#[test]
+fn test_calibrate_ignores_summary_report_option() {
+    let temp_dir = TempDir::new().unwrap();
+    let output_path = temp_dir.path().join("calibrated.bam");
+    let summary_path = temp_dir.path().join("calibrate.summary.csv");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_sequintools"))
+        .args([
+            "calibrate",
+            "--bed",
+            "testdata/resources/sequin_regions.chrQ_mirror.bed",
+            "--summary-report",
+            summary_path.to_str().unwrap(),
+            "-o",
+            output_path.to_str().unwrap(),
+            "testdata/uncalibrated.bam",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        output.status.success(),
+        "Command failed with stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains(
+        "Warning: --summary-report is deprecated and ignored. Use the bedcov command for coverage information."
+    ));
+    assert!(!summary_path.exists());
+}


### PR DESCRIPTION
hide the stale --summary-report calibrate option while keeping it accepted for backwards compatibility.
Warn when the option is supplied and remove the README documentation for summary report output, since that functionality is no longer implemented.