### PR TITLE
chore(deps): update advisory-affected dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "bindgen"
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.6.0", features = ["derive"] }
 rand = "0.10.1"
 rand_pcg = "0.10.1"
 rust-htslib = "1.0.0"
-anyhow = "1.0.102"
+anyhow = "1.0.103"
 csv = "1.4.0"
 thiserror = "2.0.18"
 rayon = "1.11.0"


### PR DESCRIPTION
Update anyhow and crossbeam-epoch in Cargo.lock to resolve cargo-deny advisories.